### PR TITLE
Amend run-service to spawn a `tini` process, which will behave better as PID 1

### DIFF
--- a/Dockerfile-clojure
+++ b/Dockerfile-clojure
@@ -1,7 +1,6 @@
 FROM clojure:alpine
 
-RUN apk add --update git perl \
-    && rm -rf /var/cache/apk
+RUN apk add --no-cache git perl tini
 
 ENV CONSUL_TEMPLATE_VERSION=0.16.0
 ENV CONSUL_TEMPLATE_SHA256SUM=064b0b492bb7ca3663811d297436a4bbf3226de706d2b76adade7021cd22e156

--- a/Dockerfile-golang
+++ b/Dockerfile-golang
@@ -1,7 +1,6 @@
 FROM golang:1.7-alpine
 
-RUN apk add --update git perl \
-    && rm -rf /var/cache/apk
+RUN apk add --no-cache git perl tini
 
 RUN go get github.com/jstemmer/go-junit-report
 

--- a/Dockerfile-openjdk
+++ b/Dockerfile-openjdk
@@ -1,7 +1,6 @@
 FROM openjdk:alpine
 
-RUN apk add --update perl \
-    && rm -rf /var/cache/apk
+RUN apk add --no-cache git perl tini
 
 ENV CONSUL_TEMPLATE_VERSION=0.16.0
 ENV CONSUL_TEMPLATE_SHA256SUM=064b0b492bb7ca3663811d297436a4bbf3226de706d2b76adade7021cd22e156

--- a/run-service
+++ b/run-service
@@ -32,7 +32,7 @@ if (defined $config and $config =~ m{^consul://(.*)$}) {
 
 unless ($dry_run) {
 	my @exec = @ARGV;
-	unshift(@exec, $PROGRAM);
+	unshift(@exec, "/sbin/tini", "--", $PROGRAM);
 	push(@exec, "--config", $real_config) unless ($exclude_config_arg or !defined $real_config);
 	exec @exec;
 }


### PR DESCRIPTION
This isn't a huge thing, but I realized it was super easy to do since `tini` has an alpine package and we're already shuffling everything through a startup script.

One thing this enables is using https://jolokia.org with our clojure (and probably UI?) containers, which in turn will enable us to use a metricbeat addition which is currently in beta, once it's out of beta, which connects to jolokia and publishes metrics on the java process.

But mostly it's just better if we have a proper init process. I don't think we're creating zombies, but we do get a lot of exit code 143 (i.e. kills) rather than SIGTERM ending processes properly, and putting tini in should make the SIGTERMs get forwarded right.